### PR TITLE
Fix issue with messages piling up

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ The name must be equal to DeviceID in OwnTracks app.
 
 ## Changelog
 
+#### 0.3.0 (2018-06-05)
+* (matspi) Fix handling of publish messages
+
 #### 0.2.0 (2017-01-03)
 * (jp112sdl) added two properties timestamp and datetime
 

--- a/io-package.json
+++ b/io-package.json
@@ -1,7 +1,7 @@
 {
     "common": {
         "name": "owntracks",
-        "version": "0.2.0",
+        "version": "0.3.0",
         "title": "OwnTracks adapter",
         "desc": {
             "en": "ioBroker OwnTracks Adapter",
@@ -9,6 +9,10 @@
             "ru": "ioBroker OwnTracks драйвер"
         },
         "news": {
+            "0.3.0": {
+                "en": "Fix handling of publish messages",
+                "de": "Problem in der Abarbeitung von publish-Nachrichten behoben"
+            },
             "0.2.0": {
                 "en": "added two properties timestamp and datetime",
                 "de": "Timestamp und datetime sind hinzugefügt",

--- a/main.js
+++ b/main.js
@@ -170,6 +170,13 @@ var cltFunction = function (client) {
         var topic   = packet.topic;
         var message = packet.payload;
         adapter.log.debug('publish "' + topic + '": ' + message);
+
+        if (packet.qos == 1) {
+            client.puback({ messageId: packet.messageId});
+        }
+        else if (packet.qos == 2) {
+            client.pubrec({ messageId: packet.messageId});
+        }
         // "owntracks/iobroker/klte":
         // {
         //      "_type":"location", // location, lwt, transition, configuration, beacon, cmd, steps, card, waypoint

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iobroker.owntracks",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "ioBroker OwnTracks Adapter",
   "author": {
     "name": "bluefox",
@@ -10,6 +10,10 @@
     {
       "name": "bluefox",
       "email": "dogafox@gmail.com"
+    },
+    {
+      "name": "matspi",
+      "email": "matthias.spiller@fari.software"
     }
   ],
   "homepage": "https://github.com/ioBroker/ioBroker.owntracks",


### PR DESCRIPTION
I had an issue with owntracks (iOS) sending messages again and again.
The number of notifications (the number in the red circle at the app icon) was increasing.

I have investigated the problem and found out that the ioBroker.owncloud adapter does not send puback messages back to owntracks, whilst the protocol demands so.
Owntracks apparently considered the publish to be not successful and tried to resend them.

This pull request should fix the issue.